### PR TITLE
Add IGNORE option to import.

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -79,7 +79,7 @@ func main() {
                 log.Fatal(err)
         }
         at.SetTableName(os.Args[1])
-        err = db.WriteTable(conn, at, "", db.IfNotExists)
+        err = db.WriteTable(conn, at, "", db.IfNotExists, db.Normal)
         if err != nil {
                 log.Fatal(err)
         }

--- a/example/dbwrite/main.go
+++ b/example/dbwrite/main.go
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = db.WriteTable(conn, at, "", db.IfNotExists)
+	err = db.WriteTable(conn, at, "", db.IfNotExists, db.Normal)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/writeTable/main.go
+++ b/example/writeTable/main.go
@@ -35,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 	at.SetTableName(os.Args[1])
-	err = db.WriteTable(conn, at, "", db.IfNotExists)
+	err = db.WriteTable(conn, at, "", db.IfNotExists, db.Normal)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Avoid conflicts as errors using the extended syntax of each DB's SQL.